### PR TITLE
Update YAML front matter in documents and the template for Quarto compatibility

### DIFF
--- a/_templates/quarto-front-matter.yml
+++ b/_templates/quarto-front-matter.yml
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,22 +15,27 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
-title:
+# Uncomment and populate the next line accordingly
+#title: Title of the document
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---

--- a/_templates/quarto-front-matter.yml
+++ b/_templates/quarto-front-matter.yml
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 #title: Title of the document
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/data/fair.md
+++ b/docs/data/fair.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: FAIR data
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/data/fair.md
+++ b/docs/data/fair.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 # date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: FAIR data
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/data/getting_started.md
+++ b/docs/data/getting_started.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Getting started
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Selin Kubilay

--- a/docs/data/getting_started.md
+++ b/docs/data/getting_started.md
@@ -2,6 +2,7 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
+# Uncomment and populate the next line accordingly
 date: 11/11/2024
 
 # We use this key to indicate the last modified date [automatic entry]
@@ -14,20 +15,25 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Getting started
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Selin Kubilay
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
+# Uncomment and populate the next line and list accordingly
 categories: 
  - FAIR
 

--- a/docs/data/project_drive_mounting.md
+++ b/docs/data/project_drive_mounting.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Mount Project Drive on Server
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Raúl Ortiz Merino
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/data/project_drive_mounting.md
+++ b/docs/data/project_drive_mounting.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Mount Project Drive on Server
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Raúl Ortiz Merino

--- a/docs/data/project_drive_request.md
+++ b/docs/data/project_drive_request.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Request Project Drive space
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/data/project_drive_request.md
+++ b/docs/data/project_drive_request.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Request Project Drive space
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/data/publishing.md
+++ b/docs/data/publishing.md
@@ -16,7 +16,12 @@ language:
 
 # Title of the document [manual entry]
 # Uncomment and populate the next line accordingly
-title: Prepare data for publishing  
+title: Prepare data for publishing
+
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
 
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly

--- a/docs/data/publishing.md
+++ b/docs/data/publishing.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Prepare data for publishing  
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Aleksandra Wilczynska
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/data/storage_options.md
+++ b/docs/data/storage_options.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: TU Delft data storage
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/data/storage_options.md
+++ b/docs/data/storage_options.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: TU Delft data storage
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/data/sync_unison.md
+++ b/docs/data/sync_unison.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Sync with Project Drive and SURFDrive with Unison
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/data/sync_unison.md
+++ b/docs/data/sync_unison.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Sync with Project Drive and SURFDrive with Unison
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/VPS_SSH.md
+++ b/docs/infrastructure/VPS_SSH.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Configure SSH Tunneling
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/VPS_SSH.md
+++ b/docs/infrastructure/VPS_SSH.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Configure SSH Tunneling
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/VPS_SSH_connect.md
+++ b/docs/infrastructure/VPS_SSH_connect.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Configure one-step SSH to server
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/VPS_SSH_connect.md
+++ b/docs/infrastructure/VPS_SSH_connect.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Configure one-step SSH to server
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/VPS_SSL_Certs.md
+++ b/docs/infrastructure/VPS_SSL_Certs.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Configure SSL certificates
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/infrastructure/VPS_SSL_Certs.md
+++ b/docs/infrastructure/VPS_SSL_Certs.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Configure SSL certificates
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/VPS_request.md
+++ b/docs/infrastructure/VPS_request.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Request a VPS
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/infrastructure/VPS_request.md
+++ b/docs/infrastructure/VPS_request.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Request a VPS
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/apache_webserver.md
+++ b/docs/infrastructure/apache_webserver.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Set up an Apache web server
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/apache_webserver.md
+++ b/docs/infrastructure/apache_webserver.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Set up an Apache web server
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/infrastructure/configure_passwordless_login.md
+++ b/docs/infrastructure/configure_passwordless_login.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Configure login with SSH
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/configure_passwordless_login.md
+++ b/docs/infrastructure/configure_passwordless_login.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Configure login with SSH
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/getting_started.md
+++ b/docs/infrastructure/getting_started.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Overview
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Maurits Kok
 author_2: Jose Urra
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/getting_started.md
+++ b/docs/infrastructure/getting_started.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Overview
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Maurits Kok

--- a/docs/infrastructure/gitlab/gitlab_docker.md
+++ b/docs/infrastructure/gitlab/gitlab_docker.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: CI with Gitlab
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/gitlab/gitlab_docker.md
+++ b/docs/infrastructure/gitlab/gitlab_docker.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: CI with Gitlab
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan

--- a/docs/infrastructure/gitlab/gitlab_groups.md
+++ b/docs/infrastructure/gitlab/gitlab_groups.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Creating GitLab groups
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/gitlab/gitlab_groups.md
+++ b/docs/infrastructure/gitlab/gitlab_groups.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Creating GitLab groups
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/gitlab/gitlab_intro.md
+++ b/docs/infrastructure/gitlab/gitlab_intro.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: TU Delft GitLab
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/gitlab/gitlab_intro.md
+++ b/docs/infrastructure/gitlab/gitlab_intro.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: TU Delft GitLab
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/gitlab/gitlab_transfer_ownership.md
+++ b/docs/infrastructure/gitlab/gitlab_transfer_ownership.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Transfer ownership of a GitLab repository
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Lora Armstrong
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/gitlab/gitlab_transfer_ownership.md
+++ b/docs/infrastructure/gitlab/gitlab_transfer_ownership.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Transfer ownership of a GitLab repository
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Lora Armstrong

--- a/docs/infrastructure/gitlab/runner_matlab.md
+++ b/docs/infrastructure/gitlab/runner_matlab.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Setting up a GitLab runner for MATLAB
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Maurits Kok

--- a/docs/infrastructure/gitlab/runner_matlab.md
+++ b/docs/infrastructure/gitlab/runner_matlab.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Setting up a GitLab runner for MATLAB
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Maurits Kok
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/giving_sudo_privilege.md
+++ b/docs/infrastructure/giving_sudo_privilege.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Giving sudo privilege to a user
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/giving_sudo_privilege.md
+++ b/docs/infrastructure/giving_sudo_privilege.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Giving sudo privilege to a user
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/intro_servers.md
+++ b/docs/infrastructure/intro_servers.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Remote servers
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/infrastructure/intro_servers.md
+++ b/docs/infrastructure/intro_servers.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Remote servers
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/moving_data.md
+++ b/docs/infrastructure/moving_data.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Moving data to your server
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/infrastructure/moving_data.md
+++ b/docs/infrastructure/moving_data.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Moving data to your server
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,6 +1,6 @@
 ---
 title: References
-#repo-actions: false
+repo-actions: false
 # listing: 
 #     type: grid
 #     categories: true

--- a/docs/listing.md
+++ b/docs/listing.md
@@ -1,6 +1,6 @@
 ---
 title: References
-repo-actions: false
+#repo-actions: false
 # listing: 
 #     type: grid
 #     categories: true

--- a/docs/resources/courses.md
+++ b/docs/resources/courses.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,24 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Courses and workshops
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
-
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 ---
 
 ## Training for researchers at the TU Delft

--- a/docs/resources/courses.md
+++ b/docs/resources/courses.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Courses and workshops
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname
@@ -37,6 +42,7 @@ title: Courses and workshops
 #categories: 
 # - 
 # - 
+
 ---
 
 ## Training for researchers at the TU Delft

--- a/docs/resources/curriculum.md
+++ b/docs/resources/curriculum.md
@@ -18,7 +18,13 @@ language:
 # Uncomment and populate the next line accordingly
 title: Research Software Curriculum
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Ashley Cryan
 author_2: Maurits Kok
 
@@ -36,7 +42,6 @@ author_2: Maurits Kok
 #categories: 
 # - 
 # - 
-
 
 ---
 

--- a/docs/resources/curriculum.md
+++ b/docs/resources/curriculum.md
@@ -118,7 +118,7 @@ These materials represent a curated curriculum designed to help you develop and 
 ## Modular Code and testing
 * [Writing tests](https://coderefinery.github.io/testing/) - lesson from CodeRefinery on automated testing
 * [Video testing lesson](https://www.youtube.com/watch?v=s72AqTTi_Y8) - recording from software testing workshop by Code Refinery
-* [Modular coding](http://cicero.xyz/v3/remark/0.14.0/github.com/coderefinery/modular-code-development/master/talk.md) - slides on modular code from Code Refinery
+* [Modular coding](https://coderefinery.github.io/modular-type-along/) - modular code development from Code Refinery
 
 ## Docker
 * [Installing Docker](https://docs.docker.com/get-docker/) - installation instructions for Windows, macOS, and Linux

--- a/docs/resources/curriculum.md
+++ b/docs/resources/curriculum.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Research Software Curriculum
 
 # Authors of the document, will not be parsed [manual entry]
 author_1: Ashley Cryan
-author_2: aurits Kok
+author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
+
 
 ---
 

--- a/docs/resources/tools.md
+++ b/docs/resources/tools.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Tools
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 🏗️ Under construction

--- a/docs/resources/tools.md
+++ b/docs/resources/tools.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Tools
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/software/checklist.md
+++ b/docs/software/checklist.md
@@ -16,6 +16,11 @@ language:
 # Title of the document [manual entry]
 title: FAIR checklist for research software
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 author_1: Maurits Kok
 author_2: Elviss Dvinskis

--- a/docs/software/checklist.md
+++ b/docs/software/checklist.md
@@ -22,14 +22,14 @@ author_2: Elviss Dvinskis
 
 # Maintainers of the document, will not be parsed [manual entry]
 maintainer_1: Elviss Dvinskis
-maintainer_2:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
 categories: 
- - FAIR
+ - FAIR Software
  - Checklist
 
 ---

--- a/docs/software/containers/docker_gui.md
+++ b/docs/software/containers/docker_gui.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Using a docker container with a GUI
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Maurits Kok
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/containers/docker_gui.md
+++ b/docs/software/containers/docker_gui.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Using a docker container with a GUI
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Maurits Kok

--- a/docs/software/containers/intro.md
+++ b/docs/software/containers/intro.md
@@ -25,8 +25,8 @@ author_1: Elviss Dvinskis
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+#maintainer_1:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis

--- a/docs/software/documentation/citation.md
+++ b/docs/software/documentation/citation.md
@@ -25,8 +25,8 @@ author_1: Elviss Dvinskis
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+#maintainer_1:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis

--- a/docs/software/documentation/index.md
+++ b/docs/software/documentation/index.md
@@ -18,19 +18,20 @@ title: Software documentation
 
 # Authors of the document, will not be parsed [manual entry]
 author_1: Maurits Kok
-author_2: 
+#author_2: 
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+#maintainer_1:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/documentation/index.md
+++ b/docs/software/documentation/index.md
@@ -16,6 +16,11 @@ language:
 # Title of the document [manual entry]
 title: Software documentation
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 author_1: Maurits Kok
 #author_2: 

--- a/docs/software/documentation/license.md
+++ b/docs/software/documentation/license.md
@@ -25,8 +25,8 @@ author_1: Elviss Dvinskis
 author_2: Maurits Kok
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+#maintainer_1:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis

--- a/docs/software/documentation/readme.md
+++ b/docs/software/documentation/readme.md
@@ -1,7 +1,43 @@
 ---
+# Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
+
+# We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
+# Uncomment and populate the next line accordingly
+#date: 11/14/2024
+
+# We use this key to indicate the last modified date [automatic entry]
+date-modified: last-modified
+
+# Do not modify
+lang: en
+language: 
+  title-block-published: "Last reviewed"
+  title-block-modified: "Last modified"
+
+# Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: README
+
+# Short description of the document, will be used in the listing
 description: Writing a good README
 hide-description: true
+
+# Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
+author_1: Maurits Kok
+author_2: Elviss Dvinskis
+
+# Maintainers of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
+maintainer_1: Elviss Dvinskis
+#maintainer_2:
+
+# To whom reach out regarding the document, will not be parsed [manual entry]
+# Uncomment and populate the next line accordingly
+corresponding: Elviss Dvinskis
+
+# Meaningful keywords, newline separated [manual entry]
+# Uncomment and populate the next line and list accordingly
 categories:
     - documentation
     - README

--- a/docs/software/fair.md
+++ b/docs/software/fair.md
@@ -22,14 +22,14 @@ author_2: Elviss Dvinskis
 
 # Maintainers of the document, will not be parsed [manual entry]
 maintainer_1: Elviss Dvinskis
-maintainer_2:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
 categories: 
- - FAIR
+ - FAIR Software
 
 ---
 

--- a/docs/software/fair.md
+++ b/docs/software/fair.md
@@ -16,6 +16,11 @@ language:
 # Title of the document [manual entry]
 title: FAIR Software
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 author_1: Maurits Kok
 author_2: Elviss Dvinskis

--- a/docs/software/getting_started.md
+++ b/docs/software/getting_started.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Getting started
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/software/getting_started.md
+++ b/docs/software/getting_started.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Getting started
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/git/branch_management.md
+++ b/docs/software/git/branch_management.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Branch management
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/git/branch_management.md
+++ b/docs/software/git/branch_management.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Branch management
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/software/git/intro.md
+++ b/docs/software/git/intro.md
@@ -16,7 +16,12 @@ language:
 
 # Title of the document [manual entry]
 # Uncomment and populate the next line accordingly
-title: Version control with Git 
+title: Version control with Git
+
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
 
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly

--- a/docs/software/git/intro.md
+++ b/docs/software/git/intro.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Version control with Git 
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/project_cards.md
+++ b/docs/software/project_cards.md
@@ -22,14 +22,14 @@ author_2: Elviss Dvinskis
 
 # Maintainers of the document, will not be parsed [manual entry]
 maintainer_1: Elviss Dvinskis
-maintainer_2:
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
 corresponding: Elviss Dvinskis
 
 # Meaningful keywords, newline separated [manual entry]
 categories: 
- - FAIR
+ - FAIR Software
  - Checklist
 
 ---

--- a/docs/software/project_cards.md
+++ b/docs/software/project_cards.md
@@ -16,6 +16,11 @@ language:
 # Title of the document [manual entry]
 title: FAIR assessment cards
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 author_1: Maurits Kok
 author_2: Elviss Dvinskis

--- a/docs/software/software_management_plan.md
+++ b/docs/software/software_management_plan.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Software management plan
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: Maurits Kok
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/software_management_plan.md
+++ b/docs/software/software_management_plan.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Software management plan
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: Maurits Kok

--- a/docs/software/testing_intro.md
+++ b/docs/software/testing_intro.md
@@ -15,7 +15,13 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Software testing
+
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
 
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly

--- a/docs/software/testing_intro.md
+++ b/docs/software/testing_intro.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -17,20 +18,24 @@ language:
 title: Software testing
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 

--- a/docs/software/testing_matlab.md
+++ b/docs/software/testing_matlab.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Testing with MATLAB
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+description: Writing and running tests with MATLAB
+hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 author_1: DCC Team
@@ -29,15 +34,14 @@ author_1: DCC Team
 #maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
+# Uncomment and populate the next line accordingly
 #corresponding:
 
 # Meaningful keywords, newline separated [manual entry]
+# Uncomment and populate the next line and list accordingly
 categories:
-    - testing
-    - matlab
-
-description: "Writing and running tests with MATLAB."
-hide-description: true    
+    - Testing
+    - MATLAB
 
 ---
 

--- a/docs/software/testing_matlab.md
+++ b/docs/software/testing_matlab.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,18 +15,21 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Testing with MATLAB
 
 # Authors of the document, will not be parsed [manual entry]
+# Uncomment and populate the next lines accordingly
 author_1: DCC Team
-author_2:
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+#corresponding:
 
 # Meaningful keywords, newline separated [manual entry]
 categories:

--- a/docs/tud-support/index.md
+++ b/docs/tud-support/index.md
@@ -18,6 +18,11 @@ language:
 # Uncomment and populate the next line accordingly
 title: Research Support Staff Guide
 
+# Brief overview of the document (will be used in listings) [manual entry]
+# Uncomment and populate the next line and uncomment "hide-description: true".
+#description: Short description of the document
+#hide-description: true
+
 # Authors of the document, will not be parsed [manual entry]
 # Uncomment and populate the next lines accordingly
 #author_1: Name Surname

--- a/docs/tud-support/index.md
+++ b/docs/tud-support/index.md
@@ -2,7 +2,8 @@
 # Insert this YAML header (including the opening and closing ---) at the beginning of the document and fill it out accordingly
 
 # We use this key to indicate the last reviewed date [manual entry, use MM/DD/YYYY]
-#date:
+# Uncomment and populate the next line accordingly
+#date: MM/DD/YYYY
 
 # We use this key to indicate the last modified date [automatic entry]
 date-modified: last-modified
@@ -14,23 +15,28 @@ language:
   title-block-modified: "Last modified"
 
 # Title of the document [manual entry]
+# Uncomment and populate the next line accordingly
 title: Research Support Staff Guide
 
 # Authors of the document, will not be parsed [manual entry]
-author_1:
-author_2:
+# Uncomment and populate the next lines accordingly
+#author_1: Name Surname
+#author_2:
 
 # Maintainers of the document, will not be parsed [manual entry]
-maintainer_1:
-maintainer_2:
+# Uncomment and populate the next lines accordingly
+#maintainer_1: Name Surname
+#maintainer_2:
 
 # To whom reach out regarding the document, will not be parsed [manual entry]
-corresponding:
+# Uncomment and populate the next line accordingly
+#corresponding: Name Surname
 
 # Meaningful keywords, newline separated [manual entry]
-categories: 
- - 
- - 
+# Uncomment and populate the next line and list accordingly
+#categories: 
+# - 
+# - 
 
 ---
 


### PR DESCRIPTION


Updated YAML front matter in documents and the template for Quarto compatibility

- Removed empty keys to prevent rendering issues
- Revised YAML structure in all documents for Quarto compatibility
- Modified template to reflect new YAML requirements
- Added comments for manual entry fields
- Included instructions for uncommenting and populating fields